### PR TITLE
fix: navbar for logged in  and logged out user

### DIFF
--- a/src/app/after_login/context/cari.jsx
+++ b/src/app/after_login/context/cari.jsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useState } from "react"
 
 export const SearchContext = createContext()
 
-export const SearchContextFunction = ({children}) => {
+export const SearchContextFunctionx = ({children}) => {
     const [searchActive, setSearchActive] = useState(false)
   return (
     <SearchContext.Provider value ={{searchActive, setSearchActive}}>

--- a/src/app/after_login/layout.js
+++ b/src/app/after_login/layout.js
@@ -1,4 +1,4 @@
-import { SearchContextFunction } from './context/cari'
+import { SearchContextFunctionx } from './context/cari'
 
 export const metadata = {
     title: 'Rental Bahari',
@@ -11,10 +11,10 @@ export const metadata = {
   
   export default function RootLayout({ children }) {
     return (
-      <SearchContextFunction>
+      <SearchContextFunctionx>
         <html lang="en">
           <body>{children}</body>
         </html>
-      </SearchContextFunction>
+      </SearchContextFunctionx>
     )
   }

--- a/src/app/booking-summary/page.jsx
+++ b/src/app/booking-summary/page.jsx
@@ -1,23 +1,46 @@
+"use client"
+
 import Link from "next/link";
 import SummaryCard from "./components/summaryCard";
 import { SearchContextFunction } from "../before_login/context/search";
+import { SearchContextFunctionx } from "../after_login/context/cari";
 import Header from "../before_login/components/navbar/header";
+import Headerx from "../after_login/components/navbar/headerx";
+import { useGetRole } from "@/hooks/useCookies";
+import { useState, useEffect } from "react";
 
 export default function BookingSummary() {
+  const [isUser, setIsUser] = useState(false);
+
+  const getRole = async () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const role = await useGetRole();
+    if (role?.value == "user") {
+      setIsUser(true);
+    }
+    console.log({ isUser });
+  };
+
+  useEffect(() => {
+    getRole();
+  }, []);
+
   return (
-    <SearchContextFunction>
-      <Header />
-      <main className="flex flex-col items-center pt-2 min-h-screen">
-        <div className="flex flex-row px-16 py-3 gap-3 w-full">
-          <Link href="/search-car" className="font-poppins font-medium">
-            &lt;
-          </Link>
-          <h1 className="font-poppins font-medium">Booking Summary</h1>
-        </div>
-        <div className="flex flex-row">
-          <SummaryCard />
-        </div>
-      </main>
-    </SearchContextFunction>
+    <SearchContextFunctionx>
+      <SearchContextFunction>
+        {isUser ? <Headerx /> : <Header />}
+        <main className="flex flex-col items-center pt-2 min-h-screen">
+          <div className="flex flex-row px-16 py-3 gap-3 w-full">
+            <Link href="/search-car" className="font-poppins font-medium">
+              &lt;
+            </Link>
+            <h1 className="font-poppins font-medium">Booking Summary</h1>
+          </div>
+          <div className="flex flex-row">
+            <SummaryCard />
+          </div>
+        </main>
+      </SearchContextFunction>
+    </SearchContextFunctionx>
   );
 }

--- a/src/app/mybooking/page.jsx
+++ b/src/app/mybooking/page.jsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React  from 'react';
-import { SearchContextFunction } from '../after_login/context/cari';
+import { SearchContextFunctionx } from '../after_login/context/cari';
 import Headerx from '../after_login/components/navbar/headerx';
 import BookingCard from './components/mybookingCard'; 
 import BookingTabs from './components/bookingTabs';
 
 function MyBookingPage() {
     return (
-        <SearchContextFunction>
+        <SearchContextFunctionx>
             <Headerx />
             <div className='flex pt-20 justify-center justify-items-center'>
                 <div className='flex flex-col'>
@@ -18,7 +18,7 @@ function MyBookingPage() {
                     <BookingCard />
                 </div>
             </div>
-        </SearchContextFunction>
+        </SearchContextFunctionx>
     );
 }
 

--- a/src/app/profile/edit/page.jsx
+++ b/src/app/profile/edit/page.jsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Image from "next/image";
-import { SearchContextFunction } from '../../after_login/context/cari';
+import { SearchContextFunctionx } from '../../after_login/context/cari';
 import Headerx from '../../after_login/components/navbar/headerx';
 import { useState, useEffect } from "react";
 import {useGetUser} from "@/hooks/useCookies";
@@ -69,7 +69,7 @@ export default function Profile(){
       };
 
     return (
-        <SearchContextFunction>
+        <SearchContextFunctionx>
             <Headerx />
             <div className="flex py-5 justify-center">
                 <div className="flex flex-col bg-slate-100 max-w-[45rem] w-full p-8 rounded-md shadow-lg mx-2 mt-5">
@@ -219,7 +219,7 @@ export default function Profile(){
 
                 </div>
             </div>
-        </SearchContextFunction>
+        </SearchContextFunctionx>
         
             
     );

--- a/src/app/profile/page.jsx
+++ b/src/app/profile/page.jsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Image from "next/image";
-import { SearchContextFunction } from '../after_login/context/cari';
+import { SearchContextFunctionx } from '../after_login/context/cari';
 import Headerx from '../after_login/components/navbar/headerx';
 import {useState, useEffect} from "react";
 import {useGetUser} from "@/hooks/useCookies";
@@ -30,7 +30,7 @@ const Profile = () => {
 
 
     return (
-        <SearchContextFunction>
+        <SearchContextFunctionx>
             <Headerx />
             <div>
                 <div className="flex py-5 justify-center">
@@ -102,7 +102,7 @@ const Profile = () => {
                     </div>
                 </div>
             </div>
-        </SearchContextFunction>
+        </SearchContextFunctionx>
     );
 }
 

--- a/src/app/search-car/page.jsx
+++ b/src/app/search-car/page.jsx
@@ -5,25 +5,44 @@ import CarList from "./components/carList";
 import FilterAndSort from "./components/filterAndSort";
 import SearchBar from "./components/searchBar";
 import { SearchContextFunction } from "../before_login/context/search";
+import { SearchContextFunctionx } from "../after_login/context/cari";
 import Header from "../before_login/components/navbar/header";
-import { useState } from "react";
+import Headerx from "../after_login/components/navbar/headerx";
+import { useGetRole } from "@/hooks/useCookies";
+import { useState, useEffect } from "react";
 import { DateContextFunction } from "./context/dateContext";
 import { FilterAndSortContextFunction } from "./context/filterAndSortContext";
 
 export default function SearchCar() {
+  const [isUser, setIsUser] = useState(false);
+
+  const getRole = async () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const role = await useGetRole();
+    if (role?.value == "user") {
+      setIsUser(true);
+    }
+    console.log({isUser});
+  };
+
+  useEffect(() => {
+    getRole();
+  }, []);
+
   return (
     <FilterAndSortContextFunction>
       <DateContextFunction>
-        <SearchContextFunction>
-          <Header />
-          <main className="flex flex-col md:flex-row min-h-screen">
-            <FilterAndSort />
-            <div className="flex flex-col w-full items-center">
-              <div className="flex flex-row w-max lg:w-max gap-4 justify-between items-center">
-                {/* <div className="hidden md:flex flex-row w-36 items-center">
+        <SearchContextFunctionx>
+          <SearchContextFunction>
+            {isUser ? <Headerx /> : <Header />}
+            <main className="flex flex-col md:flex-row min-h-screen">
+              <FilterAndSort />
+              <div className="flex flex-col w-full items-center">
+                <div className="flex flex-row w-max lg:w-max gap-4 justify-between items-center">
+                  {/* <div className="hidden md:flex flex-row w-36 items-center">
                   <p className="md:block font-medium">4 Cars Found</p>
                 </div> */}
-                {/* <div className="flex flex-row w-full justify-center">
+                  {/* <div className="flex flex-row w-full justify-center">
                   <div className="flex flex-row btn-secondary-sm lg:btn-secondary px-5 py-3 gap-3 items-center">
                     <p>Fri, 20 Oct</p>
                     <div>
@@ -42,15 +61,16 @@ export default function SearchCar() {
                     </button>
                   </div>
                 </div> */}
-                <SearchBar />
+                  <SearchBar />
+                </div>
+                <hr className="w-0 md:w-full" />
+                <div className="flex flex-col py-6 gap-6 md:gap-0 w-full items-center max-w-[36rem]">
+                  <CarList />
+                </div>
               </div>
-              <hr className="w-0 md:w-full" />
-              <div className="flex flex-col py-6 gap-6 md:gap-0 w-full items-center max-w-[36rem]">
-                <CarList />
-              </div>
-            </div>
-          </main>
-        </SearchContextFunction>
+            </main>
+          </SearchContextFunction>
+        </SearchContextFunctionx>
       </DateContextFunction>
     </FilterAndSortContextFunction>
   );


### PR DESCRIPTION
Here are the changes:
1. Before this commit, the search-car page doesn't render the correct
navbar. For example, even if the user is logged in, the page will still
render the logged out version of the navbar. In this commit, the page
should render the correct navbar for logged in and logged out users.
2. I need to change the SearchContextFunction to SearchContextFunctionx
in order to avoid the same name. Thus, I also need to change the pages
that are affected by this change.
3. In this commit, the booking-summary page should render the
corresponding navbar for both logged in and logged out users.