### PR TITLE
fix: date issue in booking-sum & search-car

### DIFF
--- a/src/app/booking-summary/components/summaryCard.jsx
+++ b/src/app/booking-summary/components/summaryCard.jsx
@@ -180,7 +180,7 @@ const SummaryCard = () => {
                 {format(
                   new Date(
                     searchParams.get("start").slice(6, 10),
-                    searchParams.get("start").slice(3, 5),
+                    searchParams.get("start").slice(3, 5) - 1,
                     searchParams.get("start").slice(0, 2)
                   ),
                   "E, dd MMM yyyy"
@@ -193,7 +193,7 @@ const SummaryCard = () => {
                 {format(
                   new Date(
                     searchParams.get("end").slice(6, 10),
-                    searchParams.get("end").slice(3, 5),
+                    searchParams.get("end").slice(3, 5) - 1,
                     searchParams.get("end").slice(0, 2)
                   ),
                   "E, dd MMM yyyy"

--- a/src/app/booking-summary/page.jsx
+++ b/src/app/booking-summary/page.jsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import Link from "next/link";
 import SummaryCard from "./components/summaryCard";
@@ -8,9 +8,11 @@ import Header from "@/app/before_login/components/navbar/Header";
 import Headerx from "@/app/after_login/components/navbar/Headerx";
 import { useGetRole } from "@/hooks/useCookies";
 import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 
 export default function BookingSummary() {
   const [isUser, setIsUser] = useState(false);
+  const searchParams = useSearchParams();
 
   const getRole = async () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -31,7 +33,16 @@ export default function BookingSummary() {
         {isUser ? <Headerx /> : <Header />}
         <main className="flex flex-col items-center pt-2 min-h-screen">
           <div className="flex flex-row px-16 py-3 gap-3 w-full">
-            <Link href="/search-car" className="font-poppins font-medium">
+            <Link
+              href={
+                "/search-car?" +
+                "&start=" +
+                searchParams.get("start") +
+                "&end=" +
+                searchParams.get("end")
+              }
+              className="font-poppins font-medium"
+            >
               &lt;
             </Link>
             <h1 className="font-poppins font-medium">Booking Summary</h1>

--- a/src/app/search-car/components/dateFunctionx.jsx
+++ b/src/app/search-car/components/dateFunctionx.jsx
@@ -24,12 +24,12 @@ export default function DateFunctionx() {
     if (searchParams.get("start") && searchParams.get("end")) {
       const start = new Date(
         searchParams.get("start").slice(6, 10),
-        searchParams.get("start").slice(3, 5),
+        searchParams.get("start").slice(3, 5) - 1,
         searchParams.get("start").slice(0, 2)
       );
       const end = new Date(
         searchParams.get("end").slice(6, 10),
-        searchParams.get("end").slice(3, 5),
+        searchParams.get("end").slice(3, 5) - 1,
         searchParams.get("end").slice(0, 2)
       );
       dateContext.setDate([


### PR DESCRIPTION
Here are the changes:
1. The month in booking-summary page was off by one. In this commit, I fix
this issue. Now, the month shouldn't be off by one anymore.
2. Before this commit, the booking month in search-car page was off by one.
In this commit, the booking month should no longer be off by one.
3. Before this commit, when user wanted to go back to the search-car page
after going to booking-summary page, the search-car page used the
default value of booking date for search-car. This was a bad ux. In this
commit, I use the start and date params in booking-summary page as 
params in search-car page. Thus, the search-car page uses the
same date as previously choosen by the user.