### PR TITLE
fix: month and time issue when creating rent doc

### DIFF
--- a/src/app/booking-summary/components/summaryCard.jsx
+++ b/src/app/booking-summary/components/summaryCard.jsx
@@ -34,9 +34,9 @@ const SummaryCard = () => {
   const start = formatISO(
     new Date(
       searchParams.get("start").slice(6, 10),
-      searchParams.get("start").slice(3, 5),
+      searchParams.get("start").slice(3, 5) - 1,
       searchParams.get("start").slice(0, 2),
-      0,
+      7,
       0,
       0
     )
@@ -44,9 +44,9 @@ const SummaryCard = () => {
   const end = formatISO(
     new Date(
       searchParams.get("end").slice(6, 10),
-      searchParams.get("end").slice(3, 5),
+      searchParams.get("end").slice(3, 5) - 1,
       searchParams.get("end").slice(0, 2),
-      0,
+      7,
       0,
       0
     )


### PR DESCRIPTION
Before this commit, when a user confirmed a booking, the rent document that were created didn't have the correct month and time. The wrong month was submitted because month, in ISO format, start at zero instead of one. In order to fix this issue, the month should be decreased by one. Meanwhile, the wrong time was used because mongodb uses GMT by default while the users don't live in places where GMT are used. I use 7 as the default hour. Keep in mind, it is a hotfix. It will only resolve the issue for users who live in GMT+7 zone.